### PR TITLE
Remove `dist` from .gitignore then re-publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ prefix-full/
 prefix-lite/
 sources/
 
-dist/
 /async/
 /sync/
 /wasm


### PR DESCRIPTION
You have all your builds and type files pointed at `dist`, but `dist` is in `.gitignore` and isn't committed.  This means you have to manually go into node_modules and build every installed instance.

This removes dist from gitgnore, which will allow your build residues into github, and thus into npm.  I have not subsequently rebuilt; that will come in a follow-up PR.

Right now most people can't use this from the `npm` package because there are no build instructions, the build scripts are missing, and there's nothing built in the repo, so it looks like to use this library you can't actually use npm, and you have to build from scratch, meaning every CI/CD build needs to install docker, bison, emscripten, and so on

I can't install several of those tools because they conflict with other things I'm doing

I hope you'll consider adding the builds and type files to github, and then re-publishing to `npm`, so that people can use this library straight from npm